### PR TITLE
Actualización de links

### DIFF
--- a/doc/instalacion_mac.md
+++ b/doc/instalacion_mac.md
@@ -16,7 +16,7 @@
 * Primero se tiene que tener instalado **Xcode**
 en caso de no tenerlo instalado lo podemos descargar [desde aqui](https://developer.apple.com/download/more/)
 (Necesitaremos una cuenta en Apple para poder acceder a la lista de descargas)
-    - Una vez lo tengamos instalado desde la misma pagina procedemos a buscar, descargar e instalar **Xcode Command Tool**
+    - Una vez lo tengamos instalado desde la misma pagina procedemos a descargar e instalar **Xcode Command Tool**
 
 ### Documentacion
 * http://manual.lenguaje-latino.org/

--- a/doc/instalacion_mac.md
+++ b/doc/instalacion_mac.md
@@ -1,55 +1,24 @@
 <p align="center">
 <img src ="https://raw.githubusercontent.com/primitivorm/latino/master/logo/banner-300x.png" /><br>http://lenguaje-latino.org/
 </p>
+
 <img src ="mac.png" />
 
-## Dependencias
-Antes de instalar latino, vamos a instalar todos paquetes necesarios:
 
-```bash
-sudo port selfupdate
-sudo port install flex bison cmake gcc g++ clang readline
-```
+### Instalar en Mac
+| Versión | Instalador |
+|---------|------------|
+|  1.1.0  | [Instalador](https://github.com/MelvinG24/Latino/releases/download/v1.1.0/Latino-1.1.0-MacOS.pkg)
 
-## INSTALAR
-```bash
- git clone --recursive https://github.com/primitivorm/latino
- cd latino
- git submodule update --init --recursive
- cmake .
- make
- sudo make install
-```
+
+#### Nota:
+**En caso de que fuera necesario**
+Instalaremos el Xcode Command Tool
+* Primero se tiene que tener instalado Xcode
+    - Una vez lo tengamos instalado, procedemos a descargar e instalar Xcode Command Tool [desde aqui](https://developer.apple.com/download/more/)
 
 ### Documentacion
-1. http://manual.lenguaje-latino.org/
-2. http://documentacion.lenguaje-latino.org/
-
-
-### Pre requisitos
-
-| Nombre paquete        | Versión
-| :---------------------|--------:
-| bison                 |  3.04
-| flex                  |  2.5.39
-| cmake                 |  3.3.1
-| gcc                   |  4.9.3
-| g++                   |  4.9.3
-| readline              |  7.0-2
-
-### DESINSTALAR
-
-#### 1- Opción
-```bash
-# Si instalaste con `sudo make install`:
-sudo bash uninstall.sh
-```
-
-#### 2- Opción
- ```
- bash
-sudo port -f uninstall latino
- ```
+* http://manual.lenguaje-latino.org/
 
 ## Ayuda en nuestro foro
 

--- a/doc/instalacion_mac.md
+++ b/doc/instalacion_mac.md
@@ -14,11 +14,11 @@
 #### Nota:
 **En caso de que fuera necesario** instalaremos el Xcode Command Tool
 * Primero se tiene que tener instalado **Xcode**
-en caso de no tenerlo instalado lo podemos descargar [desde aqui](https://developer.apple.com/download/more/)
+en caso de no tenerlo instalado lo podemos descargar [desde aquí](https://developer.apple.com/download/more/)
 (Necesitaremos una cuenta en Apple para poder acceder a la lista de descargas)
-    - Una vez lo tengamos instalado desde la misma pagina procedemos a descargar e instalar **Xcode Command Tool**
+    - Una vez lo tengamos instalado desde la misma página procedemos a descargar e instalar **Xcode Command Tool**
 
-### Documentacion
+### Documentación
 * http://manual.lenguaje-latino.org/
 
 ## Ayuda en nuestro foro

--- a/doc/instalacion_mac.md
+++ b/doc/instalacion_mac.md
@@ -12,10 +12,11 @@
 
 
 #### Nota:
-**En caso de que fuera necesario**
-Instalaremos el Xcode Command Tool
+**En caso de que fuera necesario** instalaremos el Xcode Command Tool
 * Primero se tiene que tener instalado Xcode
-    - Una vez lo tengamos instalado, procedemos a descargar e instalar Xcode Command Tool [desde aqui](https://developer.apple.com/download/more/)
+en caso de no tenerlo instalado lo podemos descargar [desde aqui](https://developer.apple.com/download/more/)
+(Necesitaremos una cuenta en Apple para poder acceder a la lista de descargas)
+    - Una vez lo tengamos instalado desde la misma pagina procedemos a buscar, descargar e instalar Xcode Command Tool
 
 ### Documentacion
 * http://manual.lenguaje-latino.org/

--- a/doc/instalacion_mac.md
+++ b/doc/instalacion_mac.md
@@ -13,10 +13,10 @@
 
 #### Nota:
 **En caso de que fuera necesario** instalaremos el Xcode Command Tool
-* Primero se tiene que tener instalado Xcode
+* Primero se tiene que tener instalado **Xcode**
 en caso de no tenerlo instalado lo podemos descargar [desde aqui](https://developer.apple.com/download/more/)
 (Necesitaremos una cuenta en Apple para poder acceder a la lista de descargas)
-    - Una vez lo tengamos instalado desde la misma pagina procedemos a buscar, descargar e instalar Xcode Command Tool
+    - Una vez lo tengamos instalado desde la misma pagina procedemos a buscar, descargar e instalar **Xcode Command Tool**
 
 ### Documentacion
 * http://manual.lenguaje-latino.org/

--- a/doc/instalacion_windows.md
+++ b/doc/instalacion_windows.md
@@ -13,7 +13,7 @@
 Puede requerir el framework de C++, descarguelo desde la pagina oficial de Microsoft:
 https://www.microsoft.com/es-ES/download/details.aspx?id=48145
 
-### Documentacion
+### Documentación
 * http://manual.lenguaje-latino.org/
 
 ### DESINSTALAR

--- a/doc/instalacion_windows.md
+++ b/doc/instalacion_windows.md
@@ -5,10 +5,12 @@
 <img src ="win.png" />
 
 ### Instalar en Windows
-1. Descargue el instalador
-2. Ejecute el instalador
+|    Version Actual    |
+|----------------------|
+|  1.1.0  | [Instalador](https://github.com/MelvinG24/Latino/releases/download/v1.1.0/Latino-1.1.0-Win.exe) |
 
-
+|  Versiones anterios  |
+|----------------------|
 | Versión | Instalador |
 |---------|------------|
 |  1.0.0  | [Instalador](https://github.com/primitivorm/latino/releases/download/v1.0/setupWindows.exe) |
@@ -20,14 +22,16 @@ Puede requerir el framework de C++, descarguelo desde la pagina oficial de Micro
 https://www.microsoft.com/es-ES/download/details.aspx?id=48145
 
 ### Documentacion
-1. http://manual.lenguaje-latino.org/
-2. http://documentacion.lenguaje-latino.org/
+• http://manual.lenguaje-latino.org/
 
 ### DESINSTALAR
-Latino se desistala como cualquier otro programa.
+Para desinstalar Latino procedemos con los siguientes pasos:
+• Inicio >
+      Panel De Control >
+            Desinstalar un Programa
+(llegado a este punto, solo tenemos que buscar el programa de Latino y darle a desinstalar)
 
 ## Ayuda en nuestro foro:
-
 http://lenguaje-latino.org/foro/windows/
 
 Cualquier aportación o sugerencia es bienvenida.

--- a/doc/instalacion_windows.md
+++ b/doc/instalacion_windows.md
@@ -5,14 +5,9 @@
 <img src ="win.png" />
 
 ### Instalar en Windows
-|    Version Actual    |
-|----------------------|
-|  1.1.0  | [Instalador](https://github.com/MelvinG24/Latino/releases/download/v1.1.0/Latino-1.1.0-Win.exe) |
-
-|  Versiones anterios  |
-|----------------------|
 | Versión | Instalador |
 |---------|------------|
+|  1.1.0  | [Instalador](https://github.com/MelvinG24/Latino/releases/download/v1.1.0/Latino-1.1.0-Win.exe) |
 |  1.0.0  | [Instalador](https://github.com/primitivorm/latino/releases/download/v1.0/setupWindows.exe) |
 |  0.9.0  | [Instalador](https://github.com/primitivorm/latino/releases/download/v0.9.0/setupWindows.exe) |
 |  0.8.11 | [Instalador](https://github.com/primitivorm/latino/releases/download/v0.8.11/setup_windows.exe) |

--- a/doc/instalacion_windows.md
+++ b/doc/instalacion_windows.md
@@ -15,20 +15,21 @@
 |---------|------------|
 |  1.0.0  | [Instalador](https://github.com/primitivorm/latino/releases/download/v1.0/setupWindows.exe) |
 |  0.9.0  | [Instalador](https://github.com/primitivorm/latino/releases/download/v0.9.0/setupWindows.exe) |
-|  0.8.11 | [Instalador]( https://github.com/primitivorm/latino/releases/download/v0.8.11/setup_windows.exe) |
+|  0.8.11 | [Instalador](https://github.com/primitivorm/latino/releases/download/v0.8.11/setup_windows.exe) |
 
 #### Nota:
 Puede requerir el framework de C++, descarguelo desde la pagina oficial de Microsoft:
 https://www.microsoft.com/es-ES/download/details.aspx?id=48145
 
 ### Documentacion
-• http://manual.lenguaje-latino.org/
+* http://manual.lenguaje-latino.org/
 
 ### DESINSTALAR
 Para desinstalar Latino procedemos con los siguientes pasos:
-• Inicio >
-      Panel De Control >
-            Desinstalar un Programa
+* **Inicio >**
+    - **Panel De Control >**
+        - **Desinstalar un Programa ...**
+        
 (llegado a este punto, solo tenemos que buscar el programa de Latino y darle a desinstalar)
 
 ## Ayuda en nuestro foro:

--- a/doc/instalacion_windows.md
+++ b/doc/instalacion_windows.md
@@ -8,9 +8,6 @@
 | Versión | Instalador |
 |---------|------------|
 |  1.1.0  | [Instalador](https://github.com/MelvinG24/Latino/releases/download/v1.1.0/Latino-1.1.0-Win.exe) |
-|  1.0.0  | [Instalador](https://github.com/primitivorm/latino/releases/download/v1.0/setupWindows.exe) |
-|  0.9.0  | [Instalador](https://github.com/primitivorm/latino/releases/download/v0.9.0/setupWindows.exe) |
-|  0.8.11 | [Instalador](https://github.com/primitivorm/latino/releases/download/v0.8.11/setup_windows.exe) |
 
 #### Nota:
 Puede requerir el framework de C++, descarguelo desde la pagina oficial de Microsoft:


### PR DESCRIPTION
Se agrego el instalador de Latino 1.1.0 para Windows, el cual corrige un error de memorial al usar el comando leer() en Windows 7 y Windows 10

Ademas, se actualizaron los links de descargas de los ReadMe files de Windows y MacOS