### PR TITLE
¿Licensia no es con 'c': Licencia? 

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,6 @@ sino
 osi
 ```
 <a name="lic"></a>
-# Licensia
+# Licencia
 Licenciado bajo la licencia [MIT](https://github.com/MelvinG24/Latino/blob/master/LICENSE.txt)<br/>
 Cualquier aportación o sugerencia es bienvenida.


### PR DESCRIPTION
Licencia se escribe con c, no con s: Licencia... es a sabiendas el error ortográfico?