### PR TITLE
Corrected Misspelling

### DIFF
--- a/src/linenoise/example.c
+++ b/src/linenoise/example.c
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
             int len = atoi(line+11);
             linenoiseHistorySetMaxLen(len);
         } else if (line[0] == '/') {
-            printf("Unreconized command: %s\n", line);
+            printf("Unrecognized command: %s\n", line);
         }
         free(line);
     }


### PR DESCRIPTION
Engish: There was a misspelling inside of the example.c
Español: corregi un palabra que no era escribida bien adentro de example.c