### PR TITLE
Sustitución de "retorno" por "regresar" y "devolver"

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Una función consiste generalmente de una lista de sentencias a ejecutar, una li
 
 Las funciones se definen con la palabra reservada `funcion` o la forma corta `fun`.
 
-Se puede regresar el valor con la palabra clave `regresar`, `retornar` o la forma corta `ret`.
+Se puede regresar el valor con la palabra clave `retornar`, `regresar`, `devolver`, o la forma corta `ret`.
 La estructura de una función es la siguiente:
 ```python
 funcion nombreFuncion (argumento1, argumento2)
@@ -520,7 +520,7 @@ mientras
 nulo
 para
 repetir
-regresar | retornar | ret
+retornar | regresar | devolver | ret
 romper
 si
 sino

--- a/ejemplos/10-funciones.lat
+++ b/ejemplos/10-funciones.lat
@@ -1,20 +1,20 @@
 funcion promedio(a,b)
-    retorno (a+b)/2
+    retornar (a+b)/2
 fin
 
 funcion max(a,b)
     si (a > b)
-        retorno a
+        retornar a
     sino
-        retorno b
+        retornar b
     fin
 fin
 
 funcion min(a,b)
     si (a < b)
-        retorno a
+        retornar a
     sino
-        retorno b
+        retornar b
     fin
 fin
 

--- a/ejemplos/11-fibonacci.lat
+++ b/ejemplos/11-fibonacci.lat
@@ -11,15 +11,15 @@
 #mala implementacion (recursiva)
 funcion fibo_rec(n)
     si ( n < 2 )
-        retorno n
+        retornar n
     fin
-    retorno fibo_rec(n-1) + fibo_rec(n-2)
+    retornar fibo_rec(n-1) + fibo_rec(n-2)
 fin
 
 #mejor implementacion (iterativa)
 funcion fibo_iter(n)
     si ( n < 2 )
-        retorno n
+        retornar n
     fin
     prevPrev = 0
     prev = 1
@@ -31,7 +31,7 @@ funcion fibo_iter(n)
         prev = res
         i = i + 1
     fin
-    retorno res
+    retornar res
 fin
 
 #imprimir la serie de 45 provoca desborde de la pila (stack overflow)

--- a/ejemplos/12-factorial.lat
+++ b/ejemplos/12-factorial.lat
@@ -20,7 +20,7 @@ funcion factorial(n)
         //poner("x vale: " .. x)
     fin
     //poner("x vale: " .. x)
-    retorno x
+    retornar x
 fin
 
 poner("el factorial de 5 es: " .. factorial(5))

--- a/ejemplos/29-funciones_anidadas.lat
+++ b/ejemplos/29-funciones_anidadas.lat
@@ -2,7 +2,7 @@ funcion algo (a,b)
   x=a*b   #x=6
   funcion inner_fun (c,d)
     #c=6, d=36
-    retorno c*c+d*d   #36+1296 = 1332
+    retornar c*c+d*d   #36+1296 = 1332
   fin
   inner_fun(x, x*x)
 fin

--- a/ejemplos/30-alcance_variables.lat
+++ b/ejemplos/30-alcance_variables.lat
@@ -23,7 +23,7 @@ funcion algo (a)
   #contexto local a la funcion
   a=15
   poner("local a dentro de la funcion:" .. a) #15
-  retorno 10
+  retornar 10
 fin
 
 #contexto global
@@ -34,7 +34,7 @@ global x=algo(a)
 global funcion cuadrado(y)
   poner("global dentro de funcion cuadrado x : " .. x)
   global a = 13 	//se cambia variable global a
-  retorno y*y
+  retornar y*y
 fin
 
 poner("global a:" .. a) #20

--- a/ejemplos/34-copiar_texto.lat
+++ b/ejemplos/34-copiar_texto.lat
@@ -14,7 +14,7 @@ elegir(opcion)
 		accion = copia
 	defecto:
 		poner("Opción inválida.")
-		retorno 0
+		retornar 0
 fin
 poner("Escribe el nombre del nuevo archivo ó de un archivo ya existente para añadir el texto")
 archivo_nuevo = leer()

--- a/ejemplos/48-match.lat
+++ b/ejemplos/48-match.lat
@@ -10,7 +10,7 @@ mientras verdadero
   es_un_correo = cadena.regex(correo, expresion)
   si es_un_correo
     poner("Correo escrito bien")
-    retorno 0
+    retornar 0
   fin
   error=verdadero
 fin

--- a/ejemplos/50-funciones_anonimas.lat
+++ b/ejemplos/50-funciones_anonimas.lat
@@ -3,11 +3,11 @@ x = funcion (a,b)
 		si b == 0
 			b=1
 		fin
-		retorno a / b
+		retornar a / b
 	fin
 
 //igual las podemos agregar a una lista
-hola = [ funcion (a, b) retorno a+b fin, funcion (a, b) retorno a*b fin ]
+hola = [ funcion (a, b) retornar a+b fin, funcion (a, b) retornar a*b fin ]
 
 //ejecutamos cada funcion
 poner(hola[0](1,2))	//suma

--- a/ejemplos/clase3_error.lat
+++ b/ejemplos/clase3_error.lat
@@ -14,7 +14,7 @@ clase Bocho : Auto
 
     #funciones sobrecargadas
     funcion Encender()
-        #retorno
+        #retornar
     fin
 
     #funcion Encender(logico l, cadena = "empty")

--- a/ejemplos/clases.lat
+++ b/ejemplos/clases.lat
@@ -8,7 +8,7 @@
 //     fin
 
 //     funcion area()
-//         retorno (mi.base*mi.altura)/2
+//         retornar (mi.base*mi.altura)/2
 //     fin
 // fin
 
@@ -18,7 +18,7 @@
 // escribir ("El area del truangulo es: ".. x.area())
 
 /*
-clase Triangulo() 
+clase Triangulo()
     base    = 0
     altura  = 0
 
@@ -29,7 +29,7 @@ clase Triangulo()
     fin
 
     funcion area()
-        retorno (mi.base*mi.altura)/2
+        retornar (mi.base*mi.altura)/2
     fin
 
     // mi = {

--- a/ejemplos/coverage.lat
+++ b/ejemplos/coverage.lat
@@ -54,37 +54,37 @@ fin
 funcion operacion(op, a, b)
 	elegir(op)
 	caso "+":
-		retorno a+b
+		retornar a+b
 	caso "-":
-		retorno a-b
+		retornar a-b
 	caso "*":
-		retorno a*b
+		retornar a*b
 	caso "/":
-		retorno a/b
+		retornar a/b
 	caso "%":
-		retorno a%b
+		retornar a%b
 	caso ">":
-		retorno a>b
+		retornar a>b
 	caso ">=":
-		retorno a>=b
+		retornar a>=b
 	caso "<":
-		retorno a<b
+		retornar a<b
 	caso "<=":
-		retorno a<=b
+		retornar a<=b
 	caso "==":
-		retorno a==b
+		retornar a==b
 	caso "!=":
-		retorno a!=b
+		retornar a!=b
 	caso "~=":
-		retorno a~=b
+		retornar a~=b
 	caso "&&":
-		retorno a&&b
+		retornar a&&b
 	caso "||":
-		retorno a||b
+		retornar a||b
 	caso "!":
-		retorno !a
+		retornar !a
 	caso "..":
-		retorno a..b
+		retornar a..b
 	fin
 fin
 
@@ -110,9 +110,9 @@ poner(operacion("..", "hola", "mundo"))
 
 funcion fibo_rec(n)
     si ( n < 2 )
-        retorno n
+        retornar n
     fin
-    retorno fibo_rec(n-1) + fibo_rec(n-2)
+    retornar fibo_rec(n-1) + fibo_rec(n-2)
 fin
 
 poner(fibo_rec(10))
@@ -189,7 +189,7 @@ imprimirf("%s %s\n", "hola", "mundo")
   x = sumar(1,2,3,4,5)
   imprimir(x)     //imprime: "15"
 
-  //una funcion multi-retorno es aquella que regresa N parametros
+  //una funcion multi-retornar es aquella que regresa N parametros
 funcion multi_ret(msg)
   #proceso el mensaje
   //mas codigo

--- a/ejemplos/modulo.lat
+++ b/ejemplos/modulo.lat
@@ -1,7 +1,7 @@
 variable = 23
 
 funcion sumatoria(a, b)
-  retorno (a + b)
+  retornar (a + b)
 fin
 
 funcion privada(arg)


### PR DESCRIPTION
En los manuales se indica que las formas de retornar un valor en una función se hace con `retornar`, `regresar` y `ret`.
Sin embargo, en el core están definidas las palabras `retornar`, `retorno` y `ret`.

Esta PR elimina el uso de la palabra reservada `retorno` a favor de `retornar` y `regresar`, definidos en los manuales.
También añade la palabra reservada nueva `devolver`, con el mismo propósito, usado en algunos otros países.

Actualizado junto a: https://github.com/lenguaje-latino/latino-Core/pull/13